### PR TITLE
Align level layout with MSX stages and add victory scene

### DIFF
--- a/src/data/levels.ts
+++ b/src/data/levels.ts
@@ -1,0 +1,416 @@
+import Phaser from 'phaser';
+
+export interface StageFruitConfig {
+  type: 'regular' | 'golden';
+  value: number;
+  offsetY?: number;
+  texture?: string;
+  timeBonus?: number;
+}
+
+export interface StageBranchConfig {
+  x: number;
+  y: number;
+  fruit?: StageFruitConfig | null;
+}
+
+export interface StageHazardEvent {
+  at: number;
+  type: 'horizontal' | 'falling';
+  fromLeft?: boolean;
+  x?: number;
+  y?: number;
+  speed?: number;
+  gravity?: number;
+}
+
+export interface LadderConfig {
+  x: number;
+  top: number;
+  bottom: number;
+  width?: number;
+}
+
+export interface StageCheckpointConfig {
+  y: number;
+  label?: string;
+}
+
+export interface StageFinaleConfig {
+  canopyY: number;
+  canopyHeight: number;
+  stairs?: LadderConfig[];
+}
+
+export interface StageItemConfig {
+  x: number;
+  y: number;
+  texture?: string;
+  value: number;
+  timeBonus?: number;
+}
+
+export interface StageDefinition {
+  id: number;
+  label: string;
+  intro: string;
+  levelHeight: number;
+  goalHeight: number;
+  timeLimit: number;
+  maxTime: number;
+  playerStart: { x: number; y: number };
+  layout: StageBranchConfig[];
+  hazardDefaults: { horizontalSpeed: number; fallingGravity: number };
+  hazardEvents: StageHazardEvent[];
+  checkpoints?: StageCheckpointConfig[];
+  ladders?: LadderConfig[];
+  items?: StageItemConfig[];
+  fruitTimeBonus: number;
+  climbZoneWidth?: number;
+  finale?: StageFinaleConfig;
+  nextStage?: number;
+  isFinal?: boolean;
+}
+
+export const LANE_POSITIONS: Record<string, number> = {
+  L: 72,
+  ML: 104,
+  MR: 152,
+  R: 184,
+  C: 128
+};
+
+const seconds = (value: number): number => value * 1000;
+
+const regularFruit = (): StageFruitConfig => ({
+  type: 'regular',
+  value: 200,
+  offsetY: 20,
+  texture: 'fruit',
+  timeBonus: 2
+});
+
+const goldenFruit = (): StageFruitConfig => ({
+  type: 'golden',
+  value: 500,
+  offsetY: 22,
+  texture: 'fruit-golden',
+  timeBonus: 4
+});
+
+const buildLayout = (
+  levelHeight: number,
+  goalHeight: number,
+  rows: string[],
+  options: { spacing?: number; startOffset?: number; goalLane?: keyof typeof LANE_POSITIONS } = {}
+): StageBranchConfig[] => {
+  const spacing = options.spacing ?? 120;
+  const startOffset = options.startOffset ?? 140;
+  const goalLane = options.goalLane ?? 'C';
+  const layout: StageBranchConfig[] = [];
+  layout.push({ x: LANE_POSITIONS.C, y: levelHeight - 42, fruit: null });
+  rows.forEach((rawRow, index) => {
+    const trimmed = rawRow.trim();
+    if (!trimmed || trimmed === '-') {
+      return;
+    }
+    const rowY = levelHeight - startOffset - index * spacing;
+    trimmed.split(/\s+/).forEach((token) => {
+      if (!token) {
+        return;
+      }
+      let laneToken = token;
+      let fruit: StageFruitConfig | null = null;
+      if (laneToken.endsWith('*')) {
+        laneToken = laneToken.slice(0, -1);
+        fruit = regularFruit();
+      }
+      if (laneToken.endsWith('!')) {
+        laneToken = laneToken.slice(0, -1);
+        fruit = goldenFruit();
+      }
+      const lane = LANE_POSITIONS[laneToken] ?? LANE_POSITIONS.C;
+      layout.push({ x: lane, y: rowY, fruit });
+    });
+  });
+  layout.push({ x: LANE_POSITIONS[goalLane], y: goalHeight + 28, fruit: null });
+  return layout;
+};
+
+const stage1Rows = [
+  'ML',
+  'MR*',
+  'L',
+  'R*',
+  'ML MR',
+  'L',
+  'R',
+  'ML*',
+  'MR',
+  'L R*',
+  'ML',
+  'MR',
+  'L*',
+  'R',
+  'ML MR*',
+  'L',
+  'R*',
+  'ML',
+  'MR',
+  'L',
+  'R',
+  'ML*',
+  'MR',
+  'R'
+];
+
+const stage2Rows = [
+  'MR',
+  'ML*',
+  'R',
+  'L',
+  'MR ML',
+  'R*',
+  'L',
+  'MR',
+  'ML*',
+  'R',
+  'L',
+  'MR',
+  'ML',
+  'R*',
+  'L',
+  'MR',
+  'ML*',
+  'R',
+  'L',
+  'MR ML',
+  'R',
+  'L*',
+  'MR',
+  'ML',
+  'R*',
+  'L',
+  'MR',
+  'ML',
+  'R'
+];
+
+const stage3Rows = [
+  'ML',
+  'MR',
+  'L*',
+  'R',
+  'ML MR',
+  'L',
+  'R*',
+  'ML',
+  'MR',
+  'L',
+  'R',
+  'ML*',
+  'MR',
+  'L',
+  'R',
+  'ML',
+  'MR*',
+  'L',
+  'R',
+  'ML',
+  'MR',
+  'L*',
+  'R',
+  'ML MR',
+  'L',
+  'R',
+  'ML*',
+  'MR',
+  'L',
+  'R',
+  'ML',
+  'MR',
+  'L*'
+];
+
+const finalRows = [
+  'ML MR',
+  'L',
+  'R',
+  'ML',
+  'MR',
+  '-',
+  '-',
+  'ML MR',
+  'L*',
+  'R',
+  'ML',
+  'MR',
+  'L',
+  'R',
+  'ML MR*',
+  'L',
+  'R',
+  'ML',
+  'MR',
+  'L',
+  'R',
+  'ML',
+  'MR',
+  'L',
+  'R',
+  'ML',
+  'MR'
+];
+
+const stage1: StageDefinition = {
+  id: 1,
+  label: 'FASE 01',
+  intro: 'SUBA AO TOPO!',
+  levelHeight: 3200,
+  goalHeight: 220,
+  timeLimit: 120,
+  maxTime: 180,
+  playerStart: { x: 128, y: 3200 - 140 },
+  layout: buildLayout(3200, 220, stage1Rows, { spacing: 120, startOffset: 140, goalLane: 'R' }),
+  hazardDefaults: { horizontalSpeed: 110, fallingGravity: 360 },
+  hazardEvents: [
+    { at: seconds(8), type: 'horizontal', fromLeft: true, y: 2200 },
+    { at: seconds(14), type: 'horizontal', fromLeft: false, y: 1800 },
+    { at: seconds(18), type: 'falling', x: 152, y: 600 },
+    { at: seconds(24), type: 'horizontal', fromLeft: true, y: 1400 },
+    { at: seconds(30), type: 'falling', x: 104, y: 500 }
+  ],
+  checkpoints: [
+    { y: 2400, label: 'CHECK A' },
+    { y: 1600, label: 'CHECK B' }
+  ],
+  ladders: [],
+  items: [
+    { x: 128, y: 2800, value: 400, texture: 'fruit-golden', timeBonus: 3 }
+  ],
+  fruitTimeBonus: 2,
+  climbZoneWidth: 48,
+  nextStage: 2
+};
+
+const stage2: StageDefinition = {
+  id: 2,
+  label: 'FASE 02',
+  intro: 'EVITE OS TROVÕES!',
+  levelHeight: 3320,
+  goalHeight: 210,
+  timeLimit: 110,
+  maxTime: 170,
+  playerStart: { x: 128, y: 3320 - 140 },
+  layout: buildLayout(3320, 210, stage2Rows, { spacing: 112, startOffset: 140, goalLane: 'ML' }),
+  hazardDefaults: { horizontalSpeed: 130, fallingGravity: 380 },
+  hazardEvents: [
+    { at: seconds(6), type: 'horizontal', fromLeft: true, y: 2500 },
+    { at: seconds(10), type: 'falling', x: 184, y: 900 },
+    { at: seconds(14), type: 'horizontal', fromLeft: false, y: 2100 },
+    { at: seconds(18), type: 'falling', x: 104, y: 780 },
+    { at: seconds(24), type: 'horizontal', fromLeft: true, y: 1700 },
+    { at: seconds(30), type: 'falling', x: 152, y: 640 },
+    { at: seconds(36), type: 'horizontal', fromLeft: false, y: 1300 }
+  ],
+  checkpoints: [
+    { y: 2500, label: 'CHECK A' },
+    { y: 1700, label: 'CHECK B' }
+  ],
+  ladders: [],
+  items: [
+    { x: 184, y: 2200, value: 400, texture: 'fruit-golden', timeBonus: 3 },
+    { x: 72, y: 1500, value: 500, texture: 'fruit-golden', timeBonus: 4 }
+  ],
+  fruitTimeBonus: 2,
+  climbZoneWidth: 48,
+  nextStage: 3
+};
+
+const stage3: StageDefinition = {
+  id: 3,
+  label: 'FASE 03',
+  intro: 'VENTOS FORTES!',
+  levelHeight: 3440,
+  goalHeight: 200,
+  timeLimit: 100,
+  maxTime: 160,
+  playerStart: { x: 128, y: 3440 - 140 },
+  layout: buildLayout(3440, 200, stage3Rows, { spacing: 108, startOffset: 140, goalLane: 'MR' }),
+  hazardDefaults: { horizontalSpeed: 150, fallingGravity: 400 },
+  hazardEvents: [
+    { at: seconds(5), type: 'horizontal', fromLeft: true, y: 2700 },
+    { at: seconds(9), type: 'falling', x: 104, y: 1000 },
+    { at: seconds(12), type: 'horizontal', fromLeft: false, y: 2300 },
+    { at: seconds(16), type: 'falling', x: 184, y: 860 },
+    { at: seconds(20), type: 'horizontal', fromLeft: true, y: 1900 },
+    { at: seconds(24), type: 'falling', x: 152, y: 720 },
+    { at: seconds(28), type: 'horizontal', fromLeft: false, y: 1500 },
+    { at: seconds(34), type: 'falling', x: 104, y: 600 }
+  ],
+  checkpoints: [
+    { y: 2600, label: 'CHECK A' },
+    { y: 1800, label: 'CHECK B' }
+  ],
+  ladders: [],
+  items: [
+    { x: 152, y: 2400, value: 500, texture: 'fruit-golden', timeBonus: 4 }
+  ],
+  fruitTimeBonus: 3,
+  climbZoneWidth: 48,
+  nextStage: 4
+};
+
+const finalStage: StageDefinition = {
+  id: 4,
+  label: 'FASE FINAL',
+  intro: 'CHEGUE À COPA!',
+  levelHeight: 3560,
+  goalHeight: 160,
+  timeLimit: 90,
+  maxTime: 150,
+  playerStart: { x: 128, y: 3560 - 140 },
+  layout: buildLayout(3560, 160, finalRows, { spacing: 104, startOffset: 148, goalLane: 'C' }),
+  hazardDefaults: { horizontalSpeed: 170, fallingGravity: 420 },
+  hazardEvents: [
+    { at: seconds(8), type: 'horizontal', fromLeft: true, y: 2600 },
+    { at: seconds(16), type: 'horizontal', fromLeft: false, y: 2100 },
+    { at: seconds(24), type: 'horizontal', fromLeft: true, y: 1600 }
+  ],
+  checkpoints: [
+    { y: 2600, label: 'CHECK A' },
+    { y: 1800, label: 'CHECK B' }
+  ],
+  ladders: [
+    { x: 128, top: 320, bottom: 600, width: 32 }
+  ],
+  items: [
+    { x: 128, y: 400, value: 800, texture: 'fruit-golden', timeBonus: 5 }
+  ],
+  fruitTimeBonus: 3,
+  climbZoneWidth: 52,
+  finale: {
+    canopyY: 280,
+    canopyHeight: 160,
+    stairs: [
+      { x: 110, top: 260, bottom: 400, width: 20 },
+      { x: 146, top: 260, bottom: 400, width: 20 }
+    ]
+  },
+  isFinal: true
+};
+
+const STAGES: StageDefinition[] = [stage1, stage2, stage3, finalStage];
+
+export const getStageDefinition = (stage: number): StageDefinition => {
+  const normalized = Phaser.Math.Clamp(stage, 1, STAGES.length);
+  const definition = STAGES.find((candidate) => candidate.id === normalized);
+  return definition ?? STAGES[STAGES.length - 1];
+};
+
+export const getStageLabel = (stage: number): string => getStageDefinition(stage).label;
+
+export const getNextStageId = (stage: number): number | undefined => {
+  const definition = getStageDefinition(stage);
+  return definition.nextStage;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import BootScene from './scenes/BootScene';
 import GameScene from './scenes/GameScene';
+import VictoryScene from './scenes/VictoryScene';
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -24,7 +25,7 @@ const config: Phaser.Types.Core.GameConfig = {
     antialias: false,
     pixelArt: true
   },
-  scene: [BootScene, GameScene]
+  scene: [BootScene, GameScene, VictoryScene]
 };
 
 export default new Phaser.Game(config);

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -18,10 +18,14 @@ export default class BootScene extends Phaser.Scene {
     this.createTrunkTexture();
     this.createBranchTexture();
     this.createFruitTexture();
+    this.createGoldenFruitTexture();
     this.createHazardTexture();
     this.createCoconutTexture();
     this.createGoalBannerTexture();
     this.createWarningTextures();
+    this.createLadderTexture();
+    this.createCheckpointTexture();
+    this.createCanopyTexture();
     this.createBackgroundTexture();
   }
 
@@ -84,6 +88,18 @@ export default class BootScene extends Phaser.Scene {
     g.destroy();
   }
 
+  private createGoldenFruitTexture(): void {
+    const g = this.add.graphics();
+    g.fillStyle(0xfff59d);
+    g.fillCircle(8, 8, 8);
+    g.lineStyle(2, 0xffca28, 0.9);
+    g.strokeCircle(8, 8, 7);
+    g.fillStyle(0x1f7f1f);
+    g.fillRect(7, 0, 2, 4);
+    g.generateTexture('fruit-golden', 16, 16);
+    g.destroy();
+  }
+
   private createHazardTexture(): void {
     const g = this.add.graphics();
     g.fillStyle(0x3f7fff);
@@ -136,6 +152,46 @@ export default class BootScene extends Phaser.Scene {
     createTriangle('warning-left', [ [0, 6], [10, 0], [10, 12] ]);
     createTriangle('warning-right', [ [12, 6], [2, 0], [2, 12] ]);
     createTriangle('warning-down', [ [6, 12], [0, 2], [12, 2] ]);
+  }
+
+  private createLadderTexture(): void {
+    const g = this.add.graphics();
+    g.fillStyle(0x4a2b12);
+    g.fillRect(0, 0, 4, 32);
+    g.fillRect(16, 0, 4, 32);
+    g.fillStyle(0xcfa26b);
+    for (let y = 4; y < 32; y += 8) {
+      g.fillRect(2, y, 16, 2);
+    }
+    g.generateTexture('ladder', 20, 32);
+    g.destroy();
+  }
+
+  private createCheckpointTexture(): void {
+    const g = this.add.graphics();
+    g.fillStyle(0x3f2a12);
+    g.fillRect(6, 0, 2, 14);
+    g.fillStyle(0xff7043);
+    g.fillTriangle(7, 1, 14, 7, 7, 13);
+    g.lineStyle(1, 0xffffff, 0.85);
+    g.strokeTriangle(7, 1, 14, 7, 7, 13);
+    g.generateTexture('checkpoint', 16, 16);
+    g.destroy();
+  }
+
+  private createCanopyTexture(): void {
+    const g = this.add.graphics();
+    g.fillStyle(0x1f5f1f);
+    g.fillRect(0, 0, 64, 64);
+    g.fillStyle(0x2f8f2f, 0.7);
+    for (let i = 0; i < 8; i += 1) {
+      const x = Phaser.Math.Between(6, 58);
+      const y = Phaser.Math.Between(6, 58);
+      const radius = Phaser.Math.Between(10, 18);
+      g.fillCircle(x, y, radius);
+    }
+    g.generateTexture('canopy', 64, 64);
+    g.destroy();
   }
 
   private createBackgroundTexture(): void {

--- a/src/scenes/VictoryScene.ts
+++ b/src/scenes/VictoryScene.ts
@@ -1,0 +1,57 @@
+import Phaser from 'phaser';
+
+export default class VictoryScene extends Phaser.Scene {
+  private finalScore = 0;
+
+  constructor() {
+    super('victory');
+  }
+
+  init(data: { score?: number } = {}): void {
+    this.finalScore = data.score ?? 0;
+  }
+
+  create(): void {
+    const background = this.add.rectangle(128, 120, 256, 240, 0x002d1f, 0.92);
+    background.setDepth(0);
+
+    const titleStyle: Phaser.Types.GameObjects.Text.TextStyle = {
+      fontSize: '12px',
+      fontFamily: '"Press Start 2P", monospace',
+      color: '#ffe082',
+      stroke: '#204010',
+      strokeThickness: 4,
+      align: 'center'
+    };
+
+    const scoreStyle: Phaser.Types.GameObjects.Text.TextStyle = {
+      ...titleStyle,
+      fontSize: '10px'
+    };
+
+    this.add.text(128, 70, 'PARABÉNS!', titleStyle).setOrigin(0.5, 0.5).setDepth(1);
+
+    const formattedScore = this.finalScore.toString().padStart(7, '0');
+    this.add.text(128, 120, `PONTOS\n${formattedScore}`, scoreStyle).setOrigin(0.5, 0.5).setDepth(1);
+
+    const prompt = this.add
+      .text(128, 170, 'PRESSIONE ESPAÇO\nPARA RECOMEÇAR', {
+        ...titleStyle,
+        fontSize: '8px'
+      })
+      .setOrigin(0.5, 0.5)
+      .setDepth(1);
+
+    this.time.addEvent({
+      delay: 800,
+      loop: true,
+      callback: () => {
+        prompt.setVisible(!prompt.visible);
+      }
+    });
+
+    this.input.keyboard.once('keydown-SPACE', () => {
+      this.scene.start('game', { stage: 1, score: 0 });
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add deterministic stage configuration including branch layouts, hazards, ladders, checkpoints, and finale metadata
- refactor the game scene to consume the configured data for branches, items, hazards, and goal transitions, including a dedicated victory flow
- add new textures and a victory scene to present the tree canopy finale and restart prompt

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e451fac824832a850e703ea3464dfc